### PR TITLE
Add drupal .env file support

### DIFF
--- a/molecule/drupal8-db-dump/converge.yml
+++ b/molecule/drupal8-db-dump/converge.yml
@@ -126,6 +126,8 @@
         steamengine_db_dump_url: https://delivery.steamulo.org/SteamEngineV2_tests/db_dump_drupal_8.zip
         steamengine_build_url: https://delivery.steamulo.org/SteamEngineV2_tests/drupal_8.zip
         steamengine_build_checksum: sha1:a354cceb222ef776644394f72f3f9278265ba6ae
+        steamengine_drupal_env: |
+          ENV_VAR_TEST=test_value
         steamengine_drupal_project_setting: |
           $databases['default']['default'] = array (
             'database' => 'drupal',

--- a/molecule/drupal8-db-dump/tests/test_default.py
+++ b/molecule/drupal8-db-dump/tests/test_default.py
@@ -19,3 +19,10 @@ def test_app_listening(host):
 def test_drupal_index_page(host):
     resp = host.run("curl --resolve 'drupal.test:80:127.0.0.1' http://drupal.test/").stdout
     assert '<a href="/" title="Accueil" rel="home">drupal</a>' in resp
+
+
+def test_drupal_env_file(host):
+    env_file = host.file(" /drupal/conf/.env")
+    assert env_file.exists
+    env_file_content = env_file.content_string
+    assert 'ENV_VAR_TEST=test_value' in env_file_content

--- a/molecule/drupal8-db-dump/tests/test_default.py
+++ b/molecule/drupal8-db-dump/tests/test_default.py
@@ -22,7 +22,7 @@ def test_drupal_index_page(host):
 
 
 def test_drupal_env_file(host):
-    env_file = host.file(" /drupal/conf/.env")
+    env_file = host.file("/drupal/conf/.env")
     assert env_file.exists
     env_file_content = env_file.content_string
     assert 'ENV_VAR_TEST=test_value' in env_file_content

--- a/molecule/drupal8-drush/converge.yml
+++ b/molecule/drupal8-drush/converge.yml
@@ -125,6 +125,8 @@
         steamengine_drupal_install_use_existing_config: true
         steamengine_build_url: https://delivery.steamulo.org/SteamEngineV2_tests/drupal_8.zip
         steamengine_build_checksum: sha1:a354cceb222ef776644394f72f3f9278265ba6ae
+        steamengine_drupal_env: |
+          ENV_VAR_TEST=test_value
         steamengine_drupal_project_setting: |
           $databases['default']['default'] = array (
             'database' => 'drupal',

--- a/molecule/drupal8-drush/tests/test_default.py
+++ b/molecule/drupal8-drush/tests/test_default.py
@@ -19,3 +19,10 @@ def test_app_listening(host):
 def test_drupal_index_page(host):
     resp = host.run("curl --resolve 'drupal.test:80:127.0.0.1' http://drupal.test/").stdout
     assert '<a href="/" title="Accueil" rel="home">drupal</a>' in resp
+
+
+def test_drupal_env_file(host):
+    env_file = host.file(" /drupal/conf/.env")
+    assert env_file.exists
+    env_file_content = env_file.content_string
+    assert 'ENV_VAR_TEST=test_value' in env_file_content

--- a/molecule/drupal8-drush/tests/test_default.py
+++ b/molecule/drupal8-drush/tests/test_default.py
@@ -22,7 +22,7 @@ def test_drupal_index_page(host):
 
 
 def test_drupal_env_file(host):
-    env_file = host.file(" /drupal/conf/.env")
+    env_file = host.file("/drupal/conf/.env")
     assert env_file.exists
     env_file_content = env_file.content_string
     assert 'ENV_VAR_TEST=test_value' in env_file_content

--- a/tasks/drupal/deploy.yml
+++ b/tasks/drupal/deploy.yml
@@ -151,7 +151,7 @@
       tags:
         - steamengine_deploy
         - steamengine_deploy_drupal
-  when: steamengine_drupal_env is defined
+  when: steamengine_drupal_env is defined and new_build_to_deploy
   tags:
     - always
 

--- a/tasks/drupal/deploy.yml
+++ b/tasks/drupal/deploy.yml
@@ -151,7 +151,9 @@
       tags:
         - steamengine_deploy
         - steamengine_deploy_drupal
-  when: steamengine_drupal_env is defined and new_build_to_deploy
+  when:
+    - steamengine_drupal_env is defined and steamengine_drupal_env
+    - new_build_to_deploy
   tags:
     - always
 

--- a/tasks/drupal/deploy.yml
+++ b/tasks/drupal/deploy.yml
@@ -151,7 +151,7 @@
       tags:
         - steamengine_deploy
         - steamengine_deploy_drupal
-  when: steamengine_drupal_env_template_path is defined
+  when: steamengine_drupal_env is defined
   tags:
     - always
 

--- a/tasks/drupal/deploy.yml
+++ b/tasks/drupal/deploy.yml
@@ -143,6 +143,18 @@
   tags:
     - steamengine_deploy_drupal
 
+# Add .env file for env_variables drupal modules: https://www.drupal.org/project/env_variables
+
+- include_tasks:
+    file: "./deploy_env_file.yml"
+    apply:
+      tags:
+        - steamengine_deploy
+        - steamengine_deploy_drupal
+  when: steamengine_drupal_env_template_path is defined
+  tags:
+    - always
+
 - name: Check if database is empty
   command: "{{ steamengine_drush_launcher_path }} -r {{ steamengine_project_root_path_web }} sql-query 'show tables'"
   register: database_table_number

--- a/tasks/drupal/deploy_env_file.yml
+++ b/tasks/drupal/deploy_env_file.yml
@@ -4,17 +4,18 @@
   file:
     state: absent
     path: "{{ steamengine_project_root_path_web }}/.env"
-  when: steamengine_drupal_env_template_path is defined
+  when: steamengine_drupal_env is defined
 
-# Template module is used because copy module is not recommended with variables : https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html)
 - name: Create external env file
-  template:
-    src: "{{ steamengine_drupal_env_template_path }}"
+  copy:
+    content: |
+      # This file is managed by Ansible, all changes will be lost.
+      {{ steamengine_drupal_env }}
     dest: "{{ steamengine_conf_path }}/.env"
     owner: "{{ steamengine_project_user }}"
     group: "{{ steamengine_app_user }}"
     mode: u=rw,g=r,o=
-  when: steamengine_drupal_env_template_path is defined
+  when: steamengine_drupal_env is defined
 
 - name: Create env symlink
   file:
@@ -23,4 +24,4 @@
     dest: "{{ steamengine_project_root_path_web }}/.env"
     owner: "{{ steamengine_project_user }}"
     group: "{{ steamengine_app_user }}"
-  when: steamengine_drupal_env_template_path is defined
+  when: steamengine_drupal_env is defined

--- a/tasks/drupal/deploy_env_file.yml
+++ b/tasks/drupal/deploy_env_file.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Remove potential env file
+  file:
+    state: absent
+    path: "{{ steamengine_project_root_path_web }}/.env"
+  when: steamengine_drupal_env_template_path is defined
+
+# Template module is used because copy module is not recommended with variables : https://docs.ansible.com/ansible/latest/collections/ansible/builtin/copy_module.html)
+- name: Create external env file
+  template:
+    src: "{{ steamengine_drupal_env_template_path }}"
+    dest: "{{ steamengine_conf_path }}/.env"
+    owner: "{{ steamengine_project_user }}"
+    group: "{{ steamengine_app_user }}"
+    mode: u=rw,g=r,o=
+  when: steamengine_drupal_env_template_path is defined
+
+- name: Create env symlink
+  file:
+    state: link
+    src: "{{ steamengine_conf_path }}/.env"
+    dest: "{{ steamengine_project_root_path_web }}/.env"
+    owner: "{{ steamengine_project_user }}"
+    group: "{{ steamengine_app_user }}"
+  when: steamengine_drupal_env_template_path is defined

--- a/tasks/drupal/deploy_env_file.yml
+++ b/tasks/drupal/deploy_env_file.yml
@@ -4,7 +4,6 @@
   file:
     state: absent
     path: "{{ steamengine_project_root_path_web }}/.env"
-  when: steamengine_drupal_env is defined
 
 - name: Create external env file
   copy:
@@ -15,7 +14,6 @@
     owner: "{{ steamengine_project_user }}"
     group: "{{ steamengine_app_user }}"
     mode: u=rw,g=r,o=
-  when: steamengine_drupal_env is defined
 
 - name: Create env symlink
   file:
@@ -24,4 +22,3 @@
     dest: "{{ steamengine_project_root_path_web }}/.env"
     owner: "{{ steamengine_project_user }}"
     group: "{{ steamengine_app_user }}"
-  when: steamengine_drupal_env is defined


### PR DESCRIPTION
Add .env files support for [env_variables drupal module](https://www.drupal.org/project/env_variables)
Can be used when passing a template path to variable *steamengine_drupal_env_template_path*