### PR TITLE
feat(drupal): add maintenance page support for Drupal

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -152,7 +152,8 @@ steamengine_drupal_install_option: >
   --locale="fr"
 # Number of db backup to keep (0 to deactive backup when deploying)
 steamengine_drupal_keep_last_n_backup: 4
-
+# Defines if we need to show the maintenance page during the deployment
+steamengine_drupal_show_maintenance_page: false
 # SYMFONY
 # List of directory we need write permission (modify for symfony < 4)
 steamengine_sf_path_with_write_permission:

--- a/tasks/drupal/deploy.yml
+++ b/tasks/drupal/deploy.yml
@@ -25,11 +25,12 @@
     - steamengine_deploy_drupal
 
 - name: "Add maintenance page"
-  become: true
   ansible.builtin.copy:
     src: "files/maintenance.html"
     dest: "{{ steamengine_project_root_path }}/maintenance.html"
-    mode: "0644"
+    owner: "{{ steamengine_project_user }}"
+    group: "{{ steamengine_app_user }}"
+    mode: u=rwx,g=rx,o=
   tags:
     - steamengine_deploy
   when: new_build_to_deploy and steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true
@@ -202,10 +203,12 @@
     - steamengine_deploy_drupal
 
 - name: "Remove maintenance page"
-  become: true
   ansible.builtin.file:
     path:  "{{ steamengine_project_root_path }}/maintenance.html"
     state: absent
+    owner: "{{ steamengine_project_user }}"
+    group: "{{ steamengine_app_user }}"
+    mode: u=rwx,g=rx,o=
   tags:
     - steamengine_deploy
   when: new_build_to_deploy and steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true

--- a/tasks/drupal/deploy.yml
+++ b/tasks/drupal/deploy.yml
@@ -1,16 +1,6 @@
 ---
 # BUILD
 
-- name: "Add maintenance page"
-  become: true
-  ansible.builtin.copy:
-    src: "files/maintenance.html"
-    dest: "{{ steamengine_project_root_path }}/maintenance.html"
-    mode: "0644"
-  tags:
-    - steamengine_deploy
-  when: steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true
-
 - name: Download build {{ steamengine_build_url }}
   ansible.builtin.get_url:
     url: "{{ steamengine_build_url }}"
@@ -33,6 +23,16 @@
     new_build_to_deploy: "{{ get_url_build.changed | bool }}"
   tags:
     - steamengine_deploy_drupal
+
+- name: "Add maintenance page"
+  become: true
+  ansible.builtin.copy:
+    src: "files/maintenance.html"
+    dest: "{{ steamengine_project_root_path }}/maintenance.html"
+    mode: "0644"
+  tags:
+    - steamengine_deploy
+  when: new_build_to_deploy and steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true
 
 - name: Create tmp directory
   ansible.builtin.tempfile:
@@ -208,4 +208,4 @@
     state: absent
   tags:
     - steamengine_deploy
-  when: steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true
+  when: new_build_to_deploy and steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true

--- a/tasks/drupal/deploy.yml
+++ b/tasks/drupal/deploy.yml
@@ -1,5 +1,16 @@
 ---
 # BUILD
+
+- name: "Add maintenance page"
+  become: true
+  ansible.builtin.copy:
+    src: "files/maintenance.html"
+    dest: "{{ steamengine_project_root_path }}/maintenance.html"
+    mode: "0644"
+  tags:
+    - steamengine_deploy_drupal
+  when: steamengine_drupal_maintenance_page_enabled is defined and steamengine_drupal_maintenance_page_enabled | bool
+
 - name: Download build {{ steamengine_build_url }}
   ansible.builtin.get_url:
     url: "{{ steamengine_build_url }}"
@@ -189,3 +200,12 @@
   when: new_build_to_deploy or steamengine_drupal_initial_install
   tags:
     - steamengine_deploy_drupal
+
+- name: "Remove maintenance page"
+  become: true
+  ansible.builtin.file:
+    path:  "{{ steamengine_project_root_path }}/maintenance.html"
+    state: absent
+  tags:
+    - steamengine_deploy_drupal
+  when: steamengine_drupal_maintenance_page_enabled is defined and steamengine_drupal_maintenance_page_enabled

--- a/tasks/drupal/deploy.yml
+++ b/tasks/drupal/deploy.yml
@@ -8,8 +8,8 @@
     dest: "{{ steamengine_project_root_path }}/maintenance.html"
     mode: "0644"
   tags:
-    - steamengine_deploy_drupal
-  when: steamengine_drupal_maintenance_page_enabled is defined and steamengine_drupal_maintenance_page_enabled | bool
+    - steamengine_deploy
+  when: steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true
 
 - name: Download build {{ steamengine_build_url }}
   ansible.builtin.get_url:
@@ -207,5 +207,5 @@
     path:  "{{ steamengine_project_root_path }}/maintenance.html"
     state: absent
   tags:
-    - steamengine_deploy_drupal
-  when: steamengine_drupal_maintenance_page_enabled is defined and steamengine_drupal_maintenance_page_enabled
+    - steamengine_deploy
+  when: steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true

--- a/tasks/drupal/deploy.yml
+++ b/tasks/drupal/deploy.yml
@@ -33,7 +33,7 @@
     mode: u=rwx,g=rx,o=
   tags:
     - steamengine_deploy
-  when: new_build_to_deploy and steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true
+  when: new_build_to_deploy and steamengine_drupal_show_maintenance_page
 
 - name: Create tmp directory
   ansible.builtin.tempfile:
@@ -211,4 +211,4 @@
     mode: u=rwx,g=rx,o=
   tags:
     - steamengine_deploy
-  when: new_build_to_deploy and steamengine_drupal_show_maintenance_page is defined and steamengine_drupal_show_maintenance_page|bool == true
+  when: new_build_to_deploy and steamengine_drupal_show_maintenance_page


### PR DESCRIPTION
goal is to add a maintenance page for Drupal websites.

Contrary to other maintenance modes already implemented in steamengine, this one will not add the maintenance page inside the www directory, because this directory is deleted by steamengine when deploying. This causes 404 page to be displayed instead of the maintenance page for a short amount of time surely but it does.