### PR TITLE
fix: correction de la valeur par défaut des variables run_in_project_root_path_web et run_as_app_user pour les crons

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,7 +4,7 @@
 steamengine_wrapper_scripts_cron: |
   {% set l = [] %}
   {% for cron in steamengine_crons %}
-  {% set _ = l.append({'name': cron.name, 'description': cron.description, 'command': cron.command, 'run_as_app_user': cron.run_as_app_user | default(omit), 'run_in_project_root_path_web': cron.run_in_project_root_path_web | default(omit)}) %}
+  {% set _ = l.append({'name': cron.name, 'description': cron.description, 'command': cron.command, 'run_as_app_user': cron.run_as_app_user | default(false), 'run_in_project_root_path_web': cron.run_in_project_root_path_web | default(false)}) %}
   {% endfor %}
   {{ l }}
 


### PR DESCRIPTION
fix: correction de la valeur par défaut des variables run_in_project_root_path_web et run_as_app_user pour les crons